### PR TITLE
PHPDOCの修正、DBトランザクションの設定、checkGender()の実装など

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@
 `contacts#index`<br />
 作成したお問合せが一覧表示される画面として実装。<br />
 表示されるカラムは`department_id`,`name`,`gender`,`email`,`content`の５種類。<br />
-<hr />
 [![Image from Gyazo](https://i.gyazo.com/cd479d7af0f34c904dad7c1742f3b911.png)](https://gyazo.com/cd479d7af0f34c904dad7c1742f3b911)
 `contacts#create`<br />
 お問合せ作成画面として作成。<br />
-<hr />
 [![Image from Gyazo](https://i.gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2.png)](https://gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2)
 以下バリデーションも実装しており、各フォームにはOldヘルパーを使用している。<br />
-<hr />
 [![Image from Gyazo](https://i.gyazo.com/df391058f838d5f9812ca0367df613b2.png)](https://gyazo.com/df391058f838d5f9812ca0367df613b2)
 
 ## チェック事項

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # php_practice
-課題ハンズオン
+課題ハンズオンのリポジトリ。
+
+## 実装した画面
+以下２つの画面を作成した。<br />
+`contacts#index`<br />
+作成したお問合せが一覧表示される画面として実装。表示されるカラムは`department_id`,`name`,`gender`,`email`,`content`の５種類。
+[![Image from Gyazo](https://i.gyazo.com/cd479d7af0f34c904dad7c1742f3b911.png)](https://gyazo.com/cd479d7af0f34c904dad7c1742f3b911)
+`contacts#create`<br />
+お問合せ作成画面として作成。
+[![Image from Gyazo](https://i.gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2.png)](https://gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2)
+以下バリデーションも実装しており、各フォームにはOldヘルパーを使用している。
+[![Image from Gyazo](https://i.gyazo.com/df391058f838d5f9812ca0367df613b2.png)](https://gyazo.com/df391058f838d5f9812ca0367df613b2)
+
+## チェック事項
+以下、正しくチェックできているか自分で確認する。
+- [ ] Dockerで環境構築できているか？ 
+- [ ] 開発環境は正確か（PHP:8.x.x, Laravel: 8.x.x） 
+- [ ] DBの設定は正しいか？（データベース名: training, DB接続ユーザー:training-user）
+- [ ] departmentsテーブルを正しく作成できているか？ 
+- [ ] seederを利用してテストデータを挿入できているか？
+- [ ] 入力フォームの内容は正しいか。
+- [ ] 「お問い合わせ先部署」はセレクトボックスによる入力としているか。
+- [ ] バリデーションは適切に設定されているか？
+- [ ] 「問い合わせ内容作成画面」は過去に作成された問い合わせ情報を一覧できる画面となっているか。
+- [ ] contacts テーブルのdepartment_idに対して外部キー制約を設けているか。
+- [ ] バリデーションはFormRequestを利用して実装しているか。 
+- [ ] Repositoryパターンに準拠し、実装を行っているか。 
+- [ ] 各種メソッドには、型宣言、PHPDOCを付与しているか。
+- [ ] コーディングルールと齟齬がないか？

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 ## 実装した画面
 以下２つの画面を作成した。<br />
 `contacts#index`<br />
-作成したお問合せが一覧表示される画面として実装。表示されるカラムは`department_id`,`name`,`gender`,`email`,`content`の５種類。
+作成したお問合せが一覧表示される画面として実装。<br />
+表示されるカラムは`department_id`,`name`,`gender`,`email`,`content`の５種類。<br />
+<hr />
 [![Image from Gyazo](https://i.gyazo.com/cd479d7af0f34c904dad7c1742f3b911.png)](https://gyazo.com/cd479d7af0f34c904dad7c1742f3b911)
 `contacts#create`<br />
-お問合せ作成画面として作成。
+お問合せ作成画面として作成。<br />
+<hr />
 [![Image from Gyazo](https://i.gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2.png)](https://gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2)
-以下バリデーションも実装しており、各フォームにはOldヘルパーを使用している。
+以下バリデーションも実装しており、各フォームにはOldヘルパーを使用している。<br />
+<hr />
 [![Image from Gyazo](https://i.gyazo.com/df391058f838d5f9812ca0367df613b2.png)](https://gyazo.com/df391058f838d5f9812ca0367df613b2)
 
 ## チェック事項

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 `contacts#index`<br />
 作成したお問合せが一覧表示される画面として実装。<br />
 表示されるカラムは`department_id`,`name`,`gender`,`email`,`content`の５種類。<br />
-[![Image from Gyazo](https://i.gyazo.com/cd479d7af0f34c904dad7c1742f3b911.png)](https://gyazo.com/cd479d7af0f34c904dad7c1742f3b911)
+[![Image from Gyazo](https://i.gyazo.com/cd479d7af0f34c904dad7c1742f3b911.png)](https://gyazo.com/cd479d7af0f34c904dad7c1742f3b911) <br />
 `contacts#create`<br />
 お問合せ作成画面として作成。<br />
-[![Image from Gyazo](https://i.gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2.png)](https://gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2)
+[![Image from Gyazo](https://i.gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2.png)](https://gyazo.com/ce93d225b94df606c7d6f9d6b0d5d7b2) <br />
 以下バリデーションも実装しており、各フォームにはOldヘルパーを使用している。<br />
-[![Image from Gyazo](https://i.gyazo.com/df391058f838d5f9812ca0367df613b2.png)](https://gyazo.com/df391058f838d5f9812ca0367df613b2)
+[![Image from Gyazo](https://i.gyazo.com/df391058f838d5f9812ca0367df613b2.png)](https://gyazo.com/df391058f838d5f9812ca0367df613b2) <br />
 
 ## チェック事項
 以下、正しくチェックできているか自分で確認する。

--- a/src/app/Http/Controllers/ContactController.php
+++ b/src/app/Http/Controllers/ContactController.php
@@ -16,7 +16,6 @@ class ContactController extends Controller
         $this->contactService = $contactService;
     }
 
-
     /**
      * お問合せの一覧を取得するメソッドです。
      *
@@ -25,7 +24,8 @@ class ContactController extends Controller
     public function index()
     {
         $contacts = $this->contactService->getContacts();
-        return view('contacts.index', compact('contacts'));
+        $genders = $this->contactService->checkGenders($contacts);
+        return view('contacts.index', compact('contacts', 'genders'));
     }
 
     /**

--- a/src/app/Http/Controllers/ContactController.php
+++ b/src/app/Http/Controllers/ContactController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\ContactServiceInterface;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use App\Http\Requests\StoreContactRequest;
 
 class ContactController extends Controller
@@ -47,9 +48,11 @@ class ContactController extends Controller
      */
     public function store(StoreContactRequest $request)
     {
-        $this->contactService->createContact(
-            $request->department_id, $request->name, $request->email, $request->content, $request->age, $request->gender
-        );
+        DB::transaction(function () use ($request) {
+            $this->contactService->createContact(
+                $request->department_id, $request->name, $request->email, $request->content, $request->age, $request->gender
+            );
+        });
 
         return redirect()->route('index');
     }

--- a/src/app/Repositories/ContactRepository.php
+++ b/src/app/Repositories/ContactRepository.php
@@ -23,7 +23,7 @@ class ContactRepository implements ContactRepositoryInterface
      */
     public function getContactsColumns()
     {
-        return Contact::select('department_id', 'name', 'email', 'content')->get();
+        return Contact::select('department_id', 'name', 'gender','email', 'content')->get();
     }
 
     /**

--- a/src/app/Repositories/ContactRepositoryInterface.php
+++ b/src/app/Repositories/ContactRepositoryInterface.php
@@ -26,7 +26,8 @@ interface ContactRepositoryInterface
     public function getContactsColumns();
 
     /**
-     * ユーザーを作成します
+     * お問合せ(Contact)を作成します
+     *
      * @param int $department_id 部署ID
      * @param string $name ユーザー名
      * @param string $email メールアドレス

--- a/src/app/Services/ContactService.php
+++ b/src/app/Services/ContactService.php
@@ -46,16 +46,24 @@ class ContactService implements ContactServiceInterface
     /**
      * @inheritDoc
      */
-    public function checkGender(Contact $contact): string
+    public function checkGenders($contacts): array
     {
-        if($contact->gender === 1) {
-            $gender = '男性'; 
-        } elseif($contact->gender === 2) {
-            $gender = '女性'; 
-        } elseif($contact->gender === 3) {
-            $gender = '未回答';
+        $genders = [];
+
+        foreach($contacts as $contact)
+        {
+            if ($contact->gender == 1) {
+                array_push($genders, '男性');
+            } 
+            if ($contact->gender == 2) {
+                array_push($genders, '女性');
+            } 
+            if ($contact->gender == 3) {
+                array_push($genders, '未回答');
+            } 
         }
-    return $gender;
+        
+        return $genders;
     }           
 
 }

--- a/src/app/Services/ContactServiceInterface.php
+++ b/src/app/Services/ContactServiceInterface.php
@@ -26,7 +26,8 @@ interface ContactServiceInterface
     public function getContacts();
 
     /**
-     * ユーザーを作成します
+     * お問合せ(Contact)を作成します
+     *
      * @param int $department_id 部署ID
      * @param string $name ユーザー名
      * @param string $email メールアドレス

--- a/src/app/Services/ContactServiceInterface.php
+++ b/src/app/Services/ContactServiceInterface.php
@@ -41,8 +41,10 @@ interface ContactServiceInterface
     /**
      * 性別の表示を「1,2,3」から「男性,女性,未回答」に変更する。
      *
-     * @return string
+     * @param $contacts 全お問合せ
+     *
+     * @return array
      */
-    public function checkGender(Contact $contact): string;
+    public function checkGenders($contacts): array;
 
 }

--- a/src/resources/views/contacts/index.blade.php
+++ b/src/resources/views/contacts/index.blade.php
@@ -28,6 +28,7 @@
                                 <tr>
                                     <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">お問合せ部署名</th>
                                     <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">氏名</th>
+                                    <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">性別</th>
                                     <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">メールアドレス</th>
                                     <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">お問合せ内容</th>
                                 </tr>
@@ -37,6 +38,7 @@
                                     <tr>
                                         <td class="border-gray-200 px-4 py-3">{{ $contact->department->name }}</td>
                                         <td class="border-gray-200 px-4 py-3">{{ $contact->name }}</td>
+                                        <td class="border-gray-200 px-4 py-3">{{ $genders[$loop->index] }}</td>
                                         <td class="border-gray-200 px-4 py-3">{{ $contact->email }}</td>
                                         <td class="border-gray-200 px-4 py-3 text-lg text-gray-900">{{ $contact->content }}</td>
                                     </tr>


### PR DESCRIPTION
## 概要
以下それぞれ実装した。
- PHPDOCの修正
- DBトランザクションの設定
- checkGenders()の実装
- READMEの整備
DBトランザクションは、自分自身メリットなどがよくわかっていないので引き続き概要を調べる。
また、checkGenders()メソッドはテーブルに保存している1,2,3という数字を一覧表示に合わせて「男性、女性、未回答」と加工するためにサービス層に実装。良い実装ではなさそうだが、とりあえずできたという感じかもしれない。

## 次の実装
- コーディングルールに反していないか全般的に確認。
- READMEの整備